### PR TITLE
feat : 지도로딩 ui

### DIFF
--- a/src/components/home/home-kakao-map.tsx
+++ b/src/components/home/home-kakao-map.tsx
@@ -9,7 +9,8 @@ import HomeKakaoMapMarker from './home-kakao-map-marker'
 import { Coordinates } from '@/types/coordinate'
 import type { Pool } from '@/types/pools'
 import { useSearchStore } from '@/stores/search-store'
-
+import { Skeleton } from '../ui/skeleton'
+import { LuLoaderCircle } from 'react-icons/lu'
 interface GeocoderResult {
   address_name: string
   region_type: string
@@ -100,32 +101,41 @@ export default function HomeKakaoMap({ searchResults }: HomeKakaoMapProps) {
 
   return (
     <div className="relative h-[200px] w-full overflow-hidden rounded-lg border">
-      <Map
-        ref={mapRef}
-        center={{
-          lat: center?.lat || DEFAULT_MAP_CENTER.lat,
-          lng: center?.lng || DEFAULT_MAP_CENTER.lng,
-        }}
-        style={{ width: '100%', height: '100%' }}
-        level={3}
-        aria-label="지도"
-        role="application"
-        onCenterChanged={handleCenterChanged}
-      >
-        {searchResults &&
-          searchResults.map((pool) => (
-            <Fragment key={pool.id}>
-              <MapMarker
-                onClick={() => clickMarker(pool.id)}
-                position={{
-                  lat: pool.latitude,
-                  lng: pool.longitude,
-                }}
-              />
-              <HomeKakaoMapMarker pool={pool} open={openMarkerId === pool.id} />
-            </Fragment>
-          ))}
-      </Map>
+      {center ? (
+        <Map
+          ref={mapRef}
+          center={{
+            lat: center.lat,
+            lng: center.lng,
+          }}
+          style={{ width: '100%', height: '100%' }}
+          level={3}
+          aria-label="지도"
+          role="application"
+          onCenterChanged={handleCenterChanged}
+        >
+          {searchResults &&
+            searchResults.map((pool) => (
+              <Fragment key={pool.id}>
+                <MapMarker
+                  onClick={() => clickMarker(pool.id)}
+                  position={{
+                    lat: pool.latitude,
+                    lng: pool.longitude,
+                  }}
+                />
+                <HomeKakaoMapMarker
+                  pool={pool}
+                  open={openMarkerId === pool.id}
+                />
+              </Fragment>
+            ))}
+        </Map>
+      ) : (
+        <Skeleton className="flex h-[200px] w-full items-center justify-center bg-slate-300">
+          <LuLoaderCircle className="animate-spin" />
+        </Skeleton>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
# 🔍 PR 개요

 메인화면 지도 로딩 UI 

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

- [ ]  메인화면 지도 로딩 UI 


## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

- Closes #이슈번호
- Related to #68 

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

<img width="601" alt="스크린샷 2025-02-02 오후 12 40 15" src="https://github.com/user-attachments/assets/f6231b54-1e0c-4a14-8447-da071ed04884" />

<!-- 테스트 항목을 체크해주세요 -->

- [x] 코드가 문제 없이 작동하는가?
- [x] 주석을 깔끔하게 달아 놓았는가?
- [x] 오류처리 되어있는가?
- [x] 로딩시 적절한 UI를 제공하는가?
- [x] 데이터가 없는 경우 적절히 처리하는가?
- [x] 코드만 봐도 최종적으로 렌더링 될 모습이 유추 가능하게 작성되었는가?
- [x] 반응형으로 구현되었는가?
- [x] 네이밍과 코드가 가독성이 좋은가?
- [x] 시맨틱 태크를 사용했는가?
- [x] any 타입을 사용하지 않았는가?

## 🔄 변경 로직 설명

기존에 사용자의 중심 좌표가 설정되기 전에 서울역좌표를 설정하도록 되어 있었는데, 이 때문에 화면 최초 진입 시 지도가 서울역에서 사용자 좌표로 순간이동하는 현상이 발생했습니다

따라서 중심좌표가 설정되지 않았으면 지도에서 로딩 UI를 보여주도록 바꾸었습니다.

