### PR TITLE
fix : 오수완 페이지 데이터 갱신 문제

### DIFF
--- a/src/app/(menu)/bulletin/page.tsx
+++ b/src/app/(menu)/bulletin/page.tsx
@@ -34,15 +34,8 @@ export default async function Bulletin() {
     staleTime: 60 * 1000,
   })
 
-  queryClient.setQueryData(['bulletin'], {
-    pages: (queryClient.getQueryData(['bulletin']) as BulletinResponse) || [],
-    pageParams: [0],
-  })
-
   return (
-    <HydrationBoundary
-      state={JSON.parse(JSON.stringify(dehydrate(queryClient)))}
-    >
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <BulletinPage />
     </HydrationBoundary>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -123,9 +123,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <head>
-        <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0d929ba008c86e3296bdbeb4f341c2cc&libraries=services&autoload=false" />
-      </head>
       <body className={`${pretendard.variable} font-pretendard antialiased`}>
         <GoogleAnalytics gaId={GA_ID} />
         <GlobalProvider>{children}</GlobalProvider>

--- a/src/components/bulletin/bulletin-item.tsx
+++ b/src/components/bulletin/bulletin-item.tsx
@@ -25,6 +25,23 @@ export default function BulletinItem({ record }: BulletinItemProps) {
     }
   }
 
+  const timeFormat = (time: string) => {
+    const now = dayjs()
+    const created = dayjs(time)
+    const diffMinutes = now.diff(created, 'minute') // 현재 시간을 분으로 치환
+
+    if (diffMinutes < 1) return '방금 전'
+    if (diffMinutes < 60) return `${diffMinutes}분 전`
+
+    const diffHours = now.diff(created, 'hour')
+    if (diffHours < 24) return `${diffHours}시간 전`
+
+    const diffDays = now.diff(created, 'day')
+    if (diffDays < 7) return `${diffDays}일 전`
+
+    return dayjs(record.created_at).format('YY.MM.DD')
+  }
+
   return (
     <div className="overflow-hidden rounded-lg bg-white shadow-md">
       <div className="relative">
@@ -59,7 +76,7 @@ export default function BulletinItem({ record }: BulletinItemProps) {
               {record.users.nickname}
             </h3>
             <time className="text-sm text-gray-500">
-              {dayjs(record.swim_date).format('YY.MM.DD')}
+              {timeFormat(record.created_at)}
             </time>
           </div>
         </div>

--- a/src/components/bulletin/bulletin-list.tsx
+++ b/src/components/bulletin/bulletin-list.tsx
@@ -10,9 +10,14 @@ interface BulletinListProps {
 export default function BulletinList({ records }: BulletinListProps) {
   return (
     <>
-      {records.map((record: Record) => (
-        <BulletinItem record={record} key={record.id} />
-      ))}
+      {records
+        .sort(
+          (a, b) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        )
+        .map((record: Record) => (
+          <BulletinItem record={record} key={record.id} />
+        ))}
     </>
   )
 }

--- a/src/components/home/home-kakao-map.tsx
+++ b/src/components/home/home-kakao-map.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Map, MapMarker } from 'react-kakao-maps-sdk'
+import { Loader, Map, MapMarker } from 'react-kakao-maps-sdk'
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { DEFAULT_MAP_CENTER } from '@/lib/constants'
 import { useDebounce } from '@/hooks/use-debounce'
@@ -34,9 +34,19 @@ export default function HomeKakaoMap({ searchResults }: HomeKakaoMapProps) {
   const [openMarkerId, setOpenMarkerId] = useState<number | null>(null)
 
   useEffect(() => {
-    kakao.maps.load(() => {
-      setGeocoder(new kakao.maps.services.Geocoder())
+    const loader = new Loader({
+      appkey: '0d929ba008c86e3296bdbeb4f341c2cc',
+      libraries: ['services'],
     })
+
+    loader
+      .load()
+      .then(() => {
+        setGeocoder(new kakao.maps.services.Geocoder())
+      })
+      .catch((error) => {
+        console.error('카카오맵 로드 실패:', error)
+      })
   }, [])
 
   const handleGeocode = useCallback(

--- a/src/components/pool/pool-kakao-map.tsx
+++ b/src/components/pool/pool-kakao-map.tsx
@@ -1,6 +1,11 @@
 import Link from 'next/link'
-import { CustomOverlayMap, Map, MapMarker } from 'react-kakao-maps-sdk'
-import { useState } from 'react'
+import {
+  CustomOverlayMap,
+  Map,
+  MapMarker,
+  useKakaoLoader,
+} from 'react-kakao-maps-sdk'
+import { useEffect, useState } from 'react'
 import type { PoolDetail } from '@/types/pools'
 
 interface PoolKaKaoMapParams {
@@ -9,6 +14,11 @@ interface PoolKaKaoMapParams {
 
 export default function PoolKaKaoMap({ pool }: PoolKaKaoMapParams) {
   const position = { lat: pool.latitude, lng: pool.longitude }
+
+  const [loading, error] = useKakaoLoader({
+    appkey: '0d929ba008c86e3296bdbeb4f341c2cc',
+    libraries: ['services'],
+  })
 
   const [isMapReady, setIsMapReady] = useState(false)
 


### PR DESCRIPTION
# 🔍 PR 개요

오수완 페이지 데이터 갱신 문제 수정

## 📝 작업 내용

- [x] 기록 일지에 내용 추가하면 오수완 페이지 바로 갱신
- [x] 시간 표기 변경
- [x] 카카오 지도 동적 로딩

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

- Related to #49

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

### Before
<img width="746" alt="스크린샷 2025-02-04 오후 2 54 33" src="https://github.com/user-attachments/assets/d8a12706-94d3-4fe7-8793-9c4a519da7b3" />


### After
<img width="715" alt="스크린샷 2025-02-04 오후 4 01 09" src="https://github.com/user-attachments/assets/7a86f5ec-9255-4aba-8678-582f59ec0cf1" />


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

- [x] 코드가 문제 없이 작동하는가?
- [x] 주석을 깔끔하게 달아 놓았는가?
- [x] 오류처리 되어있는가?
- [x] 로딩시 적절한 UI를 제공하는가?
- [x] 데이터가 없는 경우 적절히 처리하는가?
- [x] 코드만 봐도 최종적으로 렌더링 될 모습이 유추 가능하게 작성되었는가?
- [x] 반응형으로 구현되었는가?
- [x] 네이밍과 코드가 가독성이 좋은가?
- [x] 시맨틱 태크를 사용했는가?
- [x] any 타입을 사용하지 않았는가?

## 🔄 변경 로직 설명

프리패칭 시에 초기 데이터를 임의로 캐싱하여 새로운 기록 일지가 등록되고 오수완 응답이 달라져도 그 전에 캐싱했던 데이터를 보여줌
=> queryClient.setQueryData로 초기 데이터 캐싱하던 로직 삭제

root layout에서 지도 스크립트 로딩 시 ,지도가 필요없는 페이지에서 렌더링 블록 현상 발생
=> 지도가 필요한 것에서 동적 로딩

시간 표기 변경
24시간 이내에 등록된 것들을 ~ 시간 전, ~ 분 전 형식으로 표시


