### PR TITLE
Fix : 게시판 수영 시간 계산 로직 수정 및 invalidateQuery 추가

### DIFF
--- a/src/app/(menu)/bulletin/page.tsx
+++ b/src/app/(menu)/bulletin/page.tsx
@@ -16,7 +16,6 @@ export default async function Bulletin() {
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,
-        refetchOnMount: true,
         refetchOnWindowFocus: true,
       },
     },

--- a/src/app/(menu)/bulletin/page.tsx
+++ b/src/app/(menu)/bulletin/page.tsx
@@ -16,6 +16,8 @@ export default async function Bulletin() {
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,
+        refetchOnMount: true,
+        refetchOnWindowFocus: true,
       },
     },
   })

--- a/src/components/bulletin/bulletin-item.tsx
+++ b/src/components/bulletin/bulletin-item.tsx
@@ -8,7 +8,6 @@ interface BulletinItemProps {
 }
 
 export default function BulletinItem({ record }: BulletinItemProps) {
-  console.log(record)
   const calculateTime = (startTime: string | null, endTime: string | null) => {
     if (startTime === null || endTime === null) {
       return ' -- : -- '
@@ -28,7 +27,7 @@ export default function BulletinItem({ record }: BulletinItemProps) {
 
   const timeFormat = (time: string) => {
     const now = dayjs()
-    const created = dayjs(time).add(18, 'hour')
+    const created = dayjs(time).add(9, 'hour')
     const diffMinutes = now.diff(created, 'minute') // 현재 시간을 분으로 치환
 
     console.log('현재', now)

--- a/src/components/bulletin/bulletin-item.tsx
+++ b/src/components/bulletin/bulletin-item.tsx
@@ -8,24 +8,26 @@ interface BulletinItemProps {
 }
 
 export default function BulletinItem({ record }: BulletinItemProps) {
+  console.log(record)
   const calculateTime = (startTime: string | null, endTime: string | null) => {
     if (startTime === null || endTime === null) {
       return ' -- : -- '
     }
+    const [startHour, startMinute] = startTime.split(':').map(Number)
+    const [endHour, endMinute] = endTime.split(':').map(Number)
 
-    const end = dayjs(endTime)
-    const start = dayjs(startTime)
-    const diffMinutes = end.diff(start, 'minute')
+    const startTotalMinutes = startHour * 60 + startMinute
+    const endTotalMinutes = endHour * 60 + endMinute
+    const duration = endTotalMinutes - startTotalMinutes
+    const hours = Math.floor(duration / 60)
+    const minutes = duration % 60
 
-    const hour = diffMinutes / 60
-    const minute = diffMinutes % 60
-
-    if (hour === 0) {
-      return `${minute} 분`
-    } else if (minute === 0) {
-      return `${hour} 시간`
+    if (hours === 0) {
+      return `${minutes} 분`
+    } else if (minutes === 0) {
+      return `${hours} 시간`
     } else {
-      return `${hour} 시간 ${minute} 분`
+      return `${hours} 시간 ${minutes} 분`
     }
   }
 
@@ -34,9 +36,9 @@ export default function BulletinItem({ record }: BulletinItemProps) {
     const created = dayjs(time).add(9, 'hour')
     const diffMinutes = now.diff(created, 'minute') // 현재 시간을 분으로 치환
 
-    console.log('현재', now)
-    console.log('노트 생성', created)
-    console.log('차이', diffMinutes)
+    // console.log('현재', now)
+    // console.log('노트 생성', created)
+    // console.log('차이', diffMinutes)
 
     if (diffMinutes < 1) return '방금 전'
     if (diffMinutes < 60) return `${diffMinutes}분 전`

--- a/src/components/bulletin/bulletin-item.tsx
+++ b/src/components/bulletin/bulletin-item.tsx
@@ -12,9 +12,13 @@ export default function BulletinItem({ record }: BulletinItemProps) {
     if (startTime === null || endTime === null) {
       return ' -- : -- '
     }
-    const hour = Number(endTime.split(':')[0]) - Number(startTime.split(':')[0])
-    const minute =
-      Number(endTime.split(':')[1]) - Number(startTime.split(':')[1])
+
+    const end = dayjs(endTime)
+    const start = dayjs(startTime)
+    const diffMinutes = end.diff(start, 'minute')
+
+    const hour = diffMinutes / 60
+    const minute = diffMinutes % 60
 
     if (hour === 0) {
       return `${minute} 분`

--- a/src/components/bulletin/bulletin-item.tsx
+++ b/src/components/bulletin/bulletin-item.tsx
@@ -8,6 +8,7 @@ interface BulletinItemProps {
 }
 
 export default function BulletinItem({ record }: BulletinItemProps) {
+  console.log(record)
   const calculateTime = (startTime: string | null, endTime: string | null) => {
     if (startTime === null || endTime === null) {
       return ' -- : -- '
@@ -27,8 +28,12 @@ export default function BulletinItem({ record }: BulletinItemProps) {
 
   const timeFormat = (time: string) => {
     const now = dayjs()
-    const created = dayjs(time)
+    const created = dayjs(time).add(18, 'hour')
     const diffMinutes = now.diff(created, 'minute') // 현재 시간을 분으로 치환
+
+    console.log('현재', now)
+    console.log('노트 생성', created)
+    console.log('차이', diffMinutes)
 
     if (diffMinutes < 1) return '방금 전'
     if (diffMinutes < 60) return `${diffMinutes}분 전`

--- a/src/hooks/useAddSwimLogs.ts
+++ b/src/hooks/useAddSwimLogs.ts
@@ -94,5 +94,8 @@ export function useAddSwimLog({
         queryKey: createSwimLogsQueryKey({ year, month }),
       })
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bulletin'] })
+    },
   })
 }

--- a/src/hooks/useAddSwimLogs.ts
+++ b/src/hooks/useAddSwimLogs.ts
@@ -93,8 +93,6 @@ export function useAddSwimLog({
       queryClient.invalidateQueries({
         queryKey: createSwimLogsQueryKey({ year, month }),
       })
-    },
-    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bulletin'] })
     },
   })

--- a/src/hooks/useDeleteSwimLogs.ts
+++ b/src/hooks/useDeleteSwimLogs.ts
@@ -82,5 +82,8 @@ export function useDeleteSwimLog({ year, month, day }: DeleteSwimLogsParams) {
         queryKey: createSwimLogsQueryKey({ year, month, day }),
       })
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bulletin'] })
+    },
   })
 }

--- a/src/hooks/useDeleteSwimLogs.ts
+++ b/src/hooks/useDeleteSwimLogs.ts
@@ -81,8 +81,6 @@ export function useDeleteSwimLog({ year, month, day }: DeleteSwimLogsParams) {
       queryClient.invalidateQueries({
         queryKey: createSwimLogsQueryKey({ year, month, day }),
       })
-    },
-    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bulletin'] })
     },
   })


### PR DESCRIPTION
# 🔍 PR 개요

게시판 수영 시간 계산 로직 수정 및 invalidateQuery 추가

## 📝 작업 내용


- [ ] 수영 시간 계산
- [ ] 수영 기록 추가/삭제 시 쿼리 캐시 무효화

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

- Closes #64 #49 

## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

- [x] 코드가 문제 없이 작동하는가?
- [x] 주석을 깔끔하게 달아 놓았는가?
- [x] 오류처리 되어있는가?
- [x] 로딩시 적절한 UI를 제공하는가?
- [x] 데이터가 없는 경우 적절히 처리하는가?
- [x] 코드만 봐도 최종적으로 렌더링 될 모습이 유추 가능하게 작성되었는가?
- [x] 반응형으로 구현되었는가?
- [x] 네이밍과 코드가 가독성이 좋은가?
- [x] 시맨틱 태크를 사용했는가?
- [x] any 타입을 사용하지 않았는가?

## 🔄 변경 로직 설명

프로덕션에서 오수완 페이지 데이터 갱신 되는 거 확인했습니다

```js
// 예시 코드나 설명
```
